### PR TITLE
Pin quote crate to v1.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,10 @@ grok = "1"
 
 snmalloc-rs = { version = "0.2", optional = true }
 
+# Pin quote crate to resolve https://github.com/rust-lang-nursery/failure/issues/342
+# This impacts failure-derive v1.0.6 and manifests in vscode dev container
+quote = "=1.0.2"
+
 [dependencies.tungstenite]
 version = "0.10"
 default-features = false


### PR DESCRIPTION
Fixes #84 by following suggested workaround by pinning quote crate to v1.0.2.
Comment added to `Cargo.toml` as the workaround should be removed as soon as possible