### PR TITLE
Refactorings throughout `tremor-script`

### DIFF
--- a/tremor-script/src/ast.rs
+++ b/tremor-script/src/ast.rs
@@ -952,18 +952,14 @@ fn replace_last_shadow_use<'script>(replace_idx: usize, expr: Expr<'script>) -> 
         },
         Expr::Match(m) => {
             let mut m: Match<'script> = *m;
-            let mut patterns = vec![];
-            // In each pattern we can replace the use in the last assign
 
-            for mut p in m.patterns {
-                //let mut p = p.clone();
+            // In each pattern we can replace the use in the last assign
+            for p in &mut m.patterns {
                 if let Some(expr) = p.exprs.pop() {
                     p.exprs.push(replace_last_shadow_use(replace_idx, expr))
                 }
-                patterns.push(p)
             }
-            m.patterns = patterns;
-            //p.patterns
+
             Expr::Match(Box::new(m))
         }
         other => other,

--- a/tremor-script/src/ast/raw.rs
+++ b/tremor-script/src/ast/raw.rs
@@ -30,7 +30,7 @@ pub use query::*;
 use serde::Serialize;
 use simd_json::value::borrowed;
 use simd_json::{prelude::*, BorrowedValue as Value, KnownKey};
-use std::borrow::{Borrow, Cow};
+use std::borrow::Cow;
 
 /// A raw script we got to put this here because of silly lalrpoop focing it to be public
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -48,13 +48,14 @@ impl<'script> ScriptRaw<'script> {
         aggr_reg: &'registry AggrRegistry,
     ) -> Result<(Script<'script>, Vec<Warning>)> {
         let mut helper = Helper::new(reg, aggr_reg);
-        let mut consts: Vec<Value> = vec![Value::null(), Value::null(), Value::null()];
         helper.consts.insert("window".to_owned(), WINDOW_CONST_ID);
         helper.consts.insert("group".to_owned(), GROUP_CONST_ID);
         helper.consts.insert("args".to_owned(), ARGS_CONST_ID);
 
+        // TODO: Document why three `null` values are put in the constants vector.
+        let mut consts: Vec<Value> = vec![Value::null(); 3];
         let mut exprs = vec![];
-        let len = self.exprs.len();
+        let last_idx = self.exprs.len() - 1;
         for (i, e) in self.exprs.into_iter().enumerate() {
             match e {
                 ExprRaw::Const {
@@ -63,7 +64,7 @@ impl<'script> ScriptRaw<'script> {
                     start,
                     end,
                 } => {
-                    if helper.consts.contains_key(&name.to_string()) {
+                    if let Some(_prev) = helper.consts.insert(name.to_string(), consts.len()) {
                         return Err(ErrorKind::DoubleConst(
                             Range::from((start, end)).expand_lines(2),
                             Range::from((start, end)),
@@ -71,9 +72,9 @@ impl<'script> ScriptRaw<'script> {
                         )
                         .into());
                     }
-                    helper.consts.insert(name.to_string(), consts.len());
+
                     let expr = expr.up(&mut helper)?;
-                    if i == len - 1 {
+                    if i == last_idx {
                         exprs.push(Expr::Imut(ImutExprInt::Local {
                             is_const: true,
                             idx: consts.len(),
@@ -95,28 +96,21 @@ impl<'script> ScriptRaw<'script> {
         // We make sure the if we return `event` we turn it into `emit event`
         // While this is not required logically it allows us to
         // take advantage of the `emit event` optimisation
-        if let Some(e) = exprs.pop() {
-            match e.borrow() {
-                Expr::Imut(ImutExprInt::Path(Path::Event(p))) => {
-                    if p.segments.is_empty() {
-                        let expr = EmitExpr {
-                            mid: p.mid(),
-                            expr: ImutExprInt::Path(Path::Event(p.clone())),
-                            port: None,
-                        };
-                        exprs.push(Expr::Emit(Box::new(expr)))
-                    } else {
-                        exprs.push(e)
-                    }
+        if let Some(e) = exprs.last_mut() {
+            if let Expr::Imut(ImutExprInt::Path(Path::Event(p))) = e {
+                if p.segments.is_empty() {
+                    let expr = EmitExpr {
+                        mid: p.mid(),
+                        expr: ImutExprInt::Path(Path::Event(p.clone())),
+                        port: None,
+                    };
+                    *e = Expr::Emit(Box::new(expr));
                 }
-                _ => exprs.push(e),
             }
         } else {
             return Err(ErrorKind::EmptyScript.into());
         }
 
-        // let aggregates  = Vec::new();
-        // mem::swap(&mut aggregates, &mut helper.aggregates);
         Ok((
             Script {
                 exprs,
@@ -448,12 +442,13 @@ impl<'script> Upable<'script> for FnDeclRaw<'script> {
     fn up<'registry>(self, helper: &mut Helper<'script, 'registry>) -> Result<Self::Target> {
         let can_emit = helper.can_emit;
         let mut aggrs = Vec::new();
-        let mut locals = HashMap::new();
         let mut consts = HashMap::new();
-
-        for (i, a) in self.args.iter().enumerate() {
-            locals.insert(a.id.to_string(), i);
-        }
+        let mut locals: HashMap<_, _> = self
+            .args
+            .iter()
+            .enumerate()
+            .map(|(i, a)| (a.id.to_string(), i))
+            .collect();
 
         helper.can_emit = false;
         helper.swap(&mut aggrs, &mut consts, &mut locals);
@@ -640,12 +635,9 @@ impl<'script> Upable<'script> for ImutExprRaw<'script> {
                         let args: Result<Vec<Value<'script>>> =
                             i.args.into_iter().map(|v| reduce2(v.0, &helper)).collect();
                         let args = args?;
-                        let mut args2: Vec<&Value<'script>> = Vec::new();
-                        unsafe {
-                            for i in 0..args.len() {
-                                args2.push(args.get_unchecked(i));
-                            }
-                        }
+
+                        // Construct a view into `args`, since `invoke` expects a slice of references.
+                        let args2: Vec<&Value<'script>> = args.iter().collect();
                         let v = i
                             .invocable
                             .invoke(&EventContext::default(), &args2)

--- a/tremor-script/src/ast/support.rs
+++ b/tremor-script/src/ast/support.rs
@@ -77,41 +77,53 @@ impl<'script> PartialEq for StatePath<'script> {
     }
 }
 
+impl BinOpKind {
+    fn operator_name(&self) -> &'static str {
+        match self {
+            Self::Or => "or",
+            Self::Xor => "xor",
+            Self::And => "and",
+            Self::BitOr => "|",
+            Self::BitXor => "^",
+            Self::BitAnd => "&",
+            Self::Eq => "==",
+            Self::NotEq => "!=",
+            Self::Gte => ">=",
+            Self::Gt => ">",
+            Self::Lte => "<=",
+            Self::Lt => "<",
+            Self::RBitShiftSigned => ">>",
+            Self::RBitShiftUnsigned => ">>>",
+            Self::LBitShift => "<<",
+            Self::Add => "+",
+            Self::Sub => "-",
+            Self::Mul => "*",
+            Self::Div => "/",
+            Self::Mod => "%",
+        }
+    }
+}
+
 impl fmt::Display for BinOpKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.operator_name())
+    }
+}
+
+impl UnaryOpKind {
+    fn operator_name(&self) -> &'static str {
         match self {
-            Self::Or => write!(f, "or"),
-            Self::Xor => write!(f, "xor"),
-            Self::And => write!(f, "and"),
-            Self::BitOr => write!(f, "|"),
-            Self::BitXor => write!(f, "^"),
-            Self::BitAnd => write!(f, "&"),
-            Self::Eq => write!(f, "=="),
-            Self::NotEq => write!(f, "!="),
-            Self::Gte => write!(f, ">="),
-            Self::Gt => write!(f, ">"),
-            Self::Lte => write!(f, "<="),
-            Self::Lt => write!(f, "<"),
-            Self::RBitShiftSigned => write!(f, ">>"),
-            Self::RBitShiftUnsigned => write!(f, ">>>"),
-            Self::LBitShift => write!(f, "<<"),
-            Self::Add => write!(f, "+"),
-            Self::Sub => write!(f, "-"),
-            Self::Mul => write!(f, "*"),
-            Self::Div => write!(f, "/"),
-            Self::Mod => write!(f, "%"),
+            Self::Plus => "+",
+            Self::Minus => "-",
+            Self::Not => "not",
+            Self::BitNot => "!",
         }
     }
 }
 
 impl fmt::Display for UnaryOpKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Plus => write!(f, "+"),
-            Self::Minus => write!(f, "-"),
-            Self::Not => write!(f, "not"),
-            Self::BitNot => write!(f, "!"),
-        }
+        f.write_str(self.operator_name())
     }
 }
 

--- a/tremor-script/src/errors.rs
+++ b/tremor-script/src/errors.rs
@@ -123,14 +123,8 @@ pub(crate) fn best_hint(
 ) -> Option<(usize, String)> {
     options
         .iter()
-        .filter_map(|option| {
-            let d = distance::damerau_levenshtein(given, &option);
-            if d <= max_dist {
-                Some((d, option))
-            } else {
-                None
-            }
-        })
+        .map(|option| (distance::damerau_levenshtein(given, &option), option))
+        .filter(|(distance, _)| *distance <= max_dist)
         .min()
         .map(|(d, s)| (d, s.clone()))
 }

--- a/tremor-script/src/highlighter.rs
+++ b/tremor-script/src/highlighter.rs
@@ -198,8 +198,8 @@ pub trait Highlighter {
                             //
                             let delta = end.column as i64 - start.column as i64;
                             let len = usize::try_from(delta).unwrap_or(1);
-                            let prefix = String::from(" ").repeat(start.column.saturating_sub(1));
-                            let underline = String::from("^").repeat(len);
+                            let prefix = " ".repeat(start.column.saturating_sub(1));
+                            let underline = "^".repeat(len);
 
                             if let Some(token) = token {
                                 write!(self.get_writer(), "{}", token)?;
@@ -215,7 +215,7 @@ pub trait Highlighter {
                             writeln!(self.get_writer(), "{} {}", underline, callout)?;
                             self.reset()?;
                             if let Some(hint) = hint {
-                                let prefix = String::from(" ").repeat(start.column + len);
+                                let prefix = " ".repeat(start.column + len);
                                 self.set_color(ColorSpec::new().set_bold(true))?;
                                 write!(self.get_writer(), "      | {}", prefix)?;
                                 self.set_color(
@@ -270,7 +270,6 @@ pub trait Highlighter {
                 self.set_color(&mut c)?;
                 match &x.value {
                     Token::HereDoc(indent, lines) => {
-                        let space = String::from(" ");
                         writeln!(self.get_writer(), r#"""""#)?;
                         for l in lines {
                             line += 1;
@@ -279,7 +278,7 @@ pub trait Highlighter {
                             write!(self.get_writer(), "{:5} | ", line)?;
                             self.reset()?;
                             c.set_intense(true).set_fg(Some(Color::Magenta));
-                            writeln!(self.get_writer(), "{}{}", space.repeat(*indent), l)?
+                            writeln!(self.get_writer(), "{}{}", " ".repeat(*indent), l)?
                         }
                         line += 1;
                         self.reset()?;
@@ -289,7 +288,6 @@ pub trait Highlighter {
                         write!(self.get_writer(), r#"""""#)?;
                     }
                     Token::TestLiteral(indent, lines) => {
-                        let space = String::from(" ");
                         write!(self.get_writer(), "|")?;
                         let mut first = true;
                         for l in lines {
@@ -303,7 +301,7 @@ pub trait Highlighter {
                                 self.reset()?;
                                 c.set_intense(true).set_fg(Some(Color::Magenta));
                             }
-                            write!(self.get_writer(), "{}{}", space.repeat(*indent), l)?
+                            write!(self.get_writer(), "{}{}", " ".repeat(*indent), l)?
                         }
                         self.reset()?;
                         write!(self.get_writer(), "|")?;
@@ -336,8 +334,8 @@ pub trait Highlighter {
                 } else {
                     1
                 };
-                let prefix = String::from(" ").repeat(start.column - 1);
-                let underline = String::from("^").repeat(len);
+                let prefix = " ".repeat(start.column - 1);
+                let underline = "^".repeat(len);
                 if let Some(token) = token {
                     write!(self.get_writer(), "{}", token)?;
                 };
@@ -351,7 +349,7 @@ pub trait Highlighter {
                 writeln!(self.get_writer(), "{} {}", underline, callout)?;
                 self.reset()?;
                 if let Some(hint) = hint {
-                    let prefix = String::from(" ").repeat(start.column + len);
+                    let prefix = " ".repeat(start.column + len);
                     self.set_color(ColorSpec::new().set_bold(true))?;
                     write!(self.get_writer(), "      | {}", prefix)?;
                     self.set_color(ColorSpec::new().set_bold(false).set_fg(Some(Color::Yellow)))?;

--- a/tremor-script/src/interpreter.rs
+++ b/tremor-script/src/interpreter.rs
@@ -1201,11 +1201,13 @@ impl<'script> GroupByInt<'script> {
                 let v = expr
                     .run(opts, &env, event, state, meta, &local_stack)?
                     .into_owned();
-                if groups.is_empty() {
-                    groups.push(vec![v]);
+                if let Some((last_group, other_groups)) = groups.split_last_mut() {
+                    other_groups.iter_mut().for_each(|g| g.push(v.clone()));
+                    last_group.push(v)
                 } else {
-                    groups.iter_mut().for_each(|g| g.push(v.clone()));
-                };
+                    // No last group existed, i.e, `groups` was empty. Push a new group:
+                    groups.push(vec![v]);
+                }
                 Ok(())
             }
 

--- a/tremor-script/src/interpreter/expr.rs
+++ b/tremor-script/src/interpreter/expr.rs
@@ -63,17 +63,16 @@ where
         inner: &'script T,
         effectors: &'script [Expr<'script>],
     ) -> Result<Cont<'run, 'event>> {
-        if effectors.is_empty() {
-            return error_missing_effector(self, inner, &env.meta);
+        if let Some((last_effector, other_effectors)) = effectors.split_last() {
+            for effector in other_effectors {
+                demit!(effector.run(opts.without_result(), env, event, state, meta, local));
+            }
+            Ok(Cont::Cont(demit!(
+                last_effector.run(opts, env, event, state, meta, local)
+            )))
+        } else {
+            error_missing_effector(self, inner, &env.meta)
         }
-        // We know we have at least one element so [] access is safe!
-        for effector in &effectors[..effectors.len() - 1] {
-            demit!(effector.run(opts.without_result(), env, event, state, meta, local,));
-        }
-        let effector = &effectors[effectors.len() - 1];
-        Ok(Cont::Cont(demit!(
-            effector.run(opts, env, event, state, meta, local)
-        )))
     }
 
     #[inline]

--- a/tremor-script/src/lexer.rs
+++ b/tremor-script/src/lexer.rs
@@ -451,17 +451,14 @@ impl<'input> Token<'input> {
 }
 
 // LALRPOP requires a means to convert spanned tokens to triple form
-impl<'input> __ToTriple<'input> for Result<Spanned<Token<'input>>> {
+impl<'input> __ToTriple<'input> for Spanned<Token<'input>> {
     fn to_triple(
         value: Self,
     ) -> std::result::Result<
         (Location, Token<'input>, Location),
         lalrpop_util::ParseError<Location, Token<'input>, Error>,
     > {
-        match value {
-            Ok(span) => Ok((span.span.start(), span.value, span.span.end())),
-            Err(error) => Err(lalrpop_util::ParseError::User { error }),
-        }
+        Ok((value.span.start(), value.value, value.span.end()))
     }
 }
 
@@ -495,15 +492,13 @@ impl<'input> fmt::Display for Token<'input> {
             }
             Token::HereDoc(indent, lines) => {
                 writeln!(f, r#"""""#)?;
-                let space = String::from(" ");
                 for l in lines {
-                    writeln!(f, "{}{}", space.repeat(*indent), l)?
+                    writeln!(f, "{}{}", " ".repeat(*indent), l)?
                 }
                 write!(f, r#"""""#)
             }
             Token::TestLiteral(indent, values) => {
                 let mut first = true;
-                let space = String::from(" ");
                 write!(f, "|")?;
                 for l in values {
                     if first {
@@ -512,7 +507,7 @@ impl<'input> fmt::Display for Token<'input> {
                     } else {
                         writeln!(f)?;
                     };
-                    writeln!(f, "{}{}", space.repeat(*indent), l)?;
+                    writeln!(f, "{}{}", " ".repeat(*indent), l)?;
                 }
                 write!(f, "|")
             }

--- a/tremor-script/src/main.rs
+++ b/tremor-script/src/main.rs
@@ -273,7 +273,7 @@ fn main() -> Result<()> {
                             "{} ",
                             serde_json::to_string_pretty(&Return::Emit { value: event, port })?
                         );
-                        let lexed_tokens = Vec::from_iter(lexer::Tokenizer::new(&result));
+                        let lexed_tokens = lexer::Tokenizer::new(&result).collect();
                         let mut h = TermHighlighter::new();
                         h.highlight(lexed_tokens)?;
                     }
@@ -286,7 +286,7 @@ fn main() -> Result<()> {
                         println!("{}", serde_json::to_string_pretty(&result)?);
                     } else {
                         let result = format!("{} ", serde_json::to_string_pretty(&result)?);
-                        let lexed_tokens = Vec::from_iter(lexer::Tokenizer::new(&result));
+                        let lexed_tokens = lexer::Tokenizer::new(&result).collect();
                         let mut h = TermHighlighter::new();
                         h.highlight(lexed_tokens)?;
                     }

--- a/tremor-script/src/query.rs
+++ b/tremor-script/src/query.rs
@@ -112,14 +112,7 @@ where
 
         let query = rentals::Query::try_new(Box::new(source.clone()), |src| {
             let lexemes: Result<Vec<_>> = lexer::Tokenizer::new(src.as_str()).collect();
-            let mut filtered_tokens = Vec::new();
-
-            for t in lexemes? {
-                let keep = !t.value.is_ignorable();
-                if keep {
-                    filtered_tokens.push(Ok(t));
-                }
-            }
+            let filtered_tokens = lexemes?.into_iter().filter(|t| !t.value.is_ignorable());
 
             let (script, local_count, ws) = crate::parser::g::QueryParser::new()
                 .parse(filtered_tokens)?

--- a/tremor-script/src/script.rs
+++ b/tremor-script/src/script.rs
@@ -119,14 +119,7 @@ where
 
         let script = rentals::Script::try_new(Box::new(source.clone()), |src| {
             let lexemes: Result<Vec<_>> = lexer::Tokenizer::new(src.as_str()).collect();
-            let mut filtered_tokens = Vec::new();
-
-            for t in lexemes? {
-                let keep = !t.value.is_ignorable();
-                if keep {
-                    filtered_tokens.push(Ok(t));
-                }
-            }
+            let filtered_tokens = lexemes?.into_iter().filter(|t| !t.value.is_ignorable());
 
             let fake_aggr_reg = AggrRegistry::default();
             let (script, ws) = grammar::ScriptParser::new()

--- a/tremor-script/src/utils.rs
+++ b/tremor-script/src/utils.rs
@@ -26,7 +26,7 @@ pub fn hostname() -> String {
 }
 
 /// Serialize a Value in a sorted fashion to allow equality comparing the result
-pub fn sorsorted_serialize<'v>(j: &Value<'v>) -> Result<String> {
+pub fn sorsorted_serialize(j: &Value) -> Result<String> {
     // ballpark size of a 'sensible' message
     let mut w = Vec::with_capacity(512);
     sorted_serialize_(j, &mut w)?;


### PR DESCRIPTION
- Updated `Patterns.md` to fix possible out-of-bounds index, primarily by using the subslicing API for slices.
- `ast::replace_last_shadow_use`: refactor what seems to have been just an in-place update to... an in-place update.
  _**Note:**_ the code before this commit technically has different behavior in case `m.patterns` has significantly more capacity than size, as the old code would replace the vector by a smaller vector, but the new code leaves the vector as-is.
- `ast::query::raw`: removed some code duplication targeting the extraction of name/value pairs from params.
- `ast::raw`: remove double lookup by using return value of `HashMap::insert`
- `ast::raw`: replace pop-and-push-back with in-place update
- `impl Upable for FnDeclRaw`: `init HashMap` from `ExactSizeIterator`
- `impl Upable for ImutExprRaw`: remove need for `unsafe` indexing by writing in terms of an `ExactSizeIterator` API
- `impl Display for BinOpKind`: removed code duplication by extracting an `operator_name` method.
- `impl Display for UnaryOpKind`: added and used an `operator_name` method, for consistency with `BinaryOpKind` (see previous point)
- `errors::best_hint`: a separate `map` and `filter` seems clearer than a combined `filter_map` in this scenario
- `highlighter` and `lexer`: removed some unnecessary allocations of `String`: the method `repeat` is defined on `str`, not on `String`
- `GroupByInt::generate_groups`: skip unnecessary clone for last group
- `Expr::execute_effectors`: use `split_last` instead of `[len - 1]`  to get last element
- `IMutExprInt::execute_effectors`: use `last` instead of `[len - 1]` to get last element
- `IMutExprInt::invoke`: remove need for `unsafe` indexing by writing in terms of an `ExactSizeIterator` API
- `Query::parse` and `Script::parse`: simplified filtering of lexemes after initial full check and materialization. This change has as a result that `__ToTripple` can be implemented for `Spanned`, instead of for `Result<Spanned>` in the lexer.
- `util::sorsorted_serialize`: removed unnecessary lifetimes