### PR TITLE
Unify handling of key-value access

### DIFF
--- a/tremor-pipeline/src/lib.rs
+++ b/tremor-pipeline/src/lib.rs
@@ -966,7 +966,10 @@ impl Pipeline {
                 .collect(),
             stack: Vec::with_capacity(graph.len()),
             id: self.id.clone(),
-            metrics_idx: i2pos[&self.nodes["metrics"]],
+            metrics_idx: i2pos[&self
+                .nodes
+                .get("metrics")
+                .ok_or_else(|| Error::from("metrics node missing"))?],
             last_metrics: 0,
             state: State {
                 ops: iter::repeat(Value::null()).take(graph.len()).collect(),

--- a/tremor-pipeline/src/query.rs
+++ b/tremor-pipeline/src/query.rs
@@ -462,7 +462,9 @@ impl Query {
                     .collect(),
                 stack: Vec::with_capacity(graph.len()),
                 id: "generated".to_string(), // FIXME make configurable
-                metrics_idx: i2pos[&nodes["metrics"]],
+                metrics_idx: i2pos[&nodes
+                    .get("metrics")
+                    .ok_or_else(|| Error::from("metrics node missing"))?],
                 last_metrics: 0,
                 state: State {
                     ops: iter::repeat(Value::null()).take(graph.len()).collect(),


### PR DESCRIPTION
While those items will not panic since we assure existence of a "metrics" key when we build the nodes unifying to avoiding indexed access makes the code more uniform.