### PR TITLE
Fix array::contains reference

### DIFF
--- a/bench/query-real-workflow-throughput-json/main.trickle
+++ b/bench/query-real-workflow-throughput-json/main.trickle
@@ -1,5 +1,6 @@
 define script runtime
 script
+  use std::array;
   match event.application of
     case "app1" => let $class = "applog_app1",  let $rate = 1250, let $dimension = event.application, emit event
     case "app2" => let $class = "applog_app1",  let $rate = 2500, let $dimension = event.application, emit event


### PR DESCRIPTION
The `query-real-workflow-throughput-json` benchmark needs a `use std::array` in the
embedded script to run.