### PR TITLE
Add url en/de-code functions to std lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4473,6 +4473,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "matches",
+ "percent-encoding 2.1.0",
  "pretty_assertions",
  "rand 0.7.3",
  "regex",

--- a/tremor-script/Cargo.toml
+++ b/tremor-script/Cargo.toml
@@ -54,6 +54,7 @@ sketches-ddsketch = "0.1.1"
 xz2 = "0.1"
 url = "2"
 tremor-influx = { version = "0.1" }
+percent-encoding = "2.1"
 
 [build-dependencies]
 lalrpop = "0.18"

--- a/tremor-script/lib/std.tremor
+++ b/tremor-script/lib/std.tremor
@@ -19,3 +19,4 @@ use std::range;
 use std::re;
 use std::record;
 use std::string;
+use std::url;

--- a/tremor-script/lib/std/url.tremor
+++ b/tremor-script/lib/std/url.tremor
@@ -1,0 +1,11 @@
+### The url module contains functions to work on urls
+
+## Returns a url encoded UTF-8 string
+##
+## Returns a `string`
+intrinsic fn encode(str) as url::encode;
+
+## Returns a decoded UTF-8 url encoded string
+##
+## Returns a `string`
+intrinsic fn decode(str) as url::decode;

--- a/tremor-script/src/std_lib.rs
+++ b/tremor-script/src/std_lib.rs
@@ -30,6 +30,7 @@ mod string;
 mod system;
 mod test;
 mod r#type;
+mod url;
 mod win;
 
 use crate::registry::{Aggr as AggrRegistry, Registry};
@@ -52,6 +53,7 @@ pub fn load(registry: &mut Registry) {
     system::load(registry);
     test::load(registry);
     r#type::load(registry);
+    url::load(registry);
 }
 
 pub fn load_aggr(registry: &mut AggrRegistry) {

--- a/tremor-script/src/std_lib/url.rs
+++ b/tremor-script/src/std_lib/url.rs
@@ -20,8 +20,7 @@ use simd_json::BorrowedValue;
 pub fn load(registry: &mut Registry) {
     registry
         .insert(tremor_fn! (url::decode(ctx, s: String) {
-            let ss = s.to_string();
-            let ds = percent_decode_str(&ss).decode_utf8();
+            let ds = percent_decode_str(&s).decode_utf8();
             if let Ok(decoded) = ds {
                 Ok(BorrowedValue::from(decoded.to_string()))
             } else {

--- a/tremor-script/src/std_lib/url.rs
+++ b/tremor-script/src/std_lib/url.rs
@@ -1,0 +1,59 @@
+// Copyright 2018-2020, Wayfair GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::registry::Registry;
+use crate::tremor_fn;
+use percent_encoding::{percent_decode_str, utf8_percent_encode, NON_ALPHANUMERIC};
+use simd_json::BorrowedValue;
+
+pub fn load(registry: &mut Registry) {
+    registry
+        .insert(tremor_fn! (url::decode(ctx, s: String) {
+            let ss = s.to_string();
+            let ds = percent_decode_str(&ss).decode_utf8();
+            if let Ok(decoded) = ds {
+                Ok(BorrowedValue::from(decoded.to_string()))
+            } else {
+                Err(to_runtime_error(format!("Could not urldecode value: {}", s)))
+            }
+        }))
+        .insert(tremor_fn! (url::encode(ctx, s: String) {
+            Ok(BorrowedValue::from(utf8_percent_encode(&s, NON_ALPHANUMERIC).to_string()))
+        }));
+}
+
+#[cfg(test)]
+mod test {
+    use crate::registry::fun;
+    use simd_json::BorrowedValue as Value;
+    //    use std::borrow::Cow;
+
+    macro_rules! assert_val {
+        ($e:expr, $r:expr) => {
+            assert_eq!($e, Ok(Value::from($r)))
+        };
+    }
+
+    #[test]
+    fn shook_endecode_smoke_test() {
+        let d = fun("url", "decode");
+        let e = fun("url", "encode");
+
+        let v = Value::from("snot badger");
+        assert_val!(e(&[&v]), "snot%20badger");
+
+        let v = Value::from("%22snot%20badger%22");
+        assert_val!(d(&[&v]), r#""snot badger""#);
+    }
+}


### PR DESCRIPTION
Adds url encode and decode functions to handle percent encoded
strings.

Example:

```
use std::url;

url::decode(url::encode("foo bar baz"))
```