### PR TITLE
Fix race condition in query exit test ramp configuration

### DIFF
--- a/integration_testing/basic/query-exit.test/config.yaml
+++ b/integration_testing/basic/query-exit.test/config.yaml
@@ -3,7 +3,7 @@ onramp:
     type: file
     config:
       source: {in}
-      close_on_done: true
+      close_on_done: false
 
 offramp:
   - id: out


### PR DESCRIPTION
Setting `close_on_done` in the file onramp potentially races with
an exit event in the offramp resulting in incorrect exit status and/or
intermittent failing tests in CI.

Unable to replicate locally race condition locally, but its reasonably
frequent in CI. This change is speculative / to be confirmed by CI
behaviour ( it should fix periodic failures in CI tests as an effect ).