### PR TITLE
Fix tremor-script visibility in external crates for v0.8

### DIFF
--- a/tremor-script/src/lexer.rs
+++ b/tremor-script/src/lexer.rs
@@ -797,7 +797,7 @@ impl fmt::Display for CompilationUnit {
     }
 }
 
-pub(crate) struct IncludeStack {
+pub struct IncludeStack {
     elements: Vec<CompilationUnit>,
     pub(crate) cus: Vec<CompilationUnit>,
 }
@@ -881,7 +881,7 @@ impl<'input> Preprocessor {
     }
 
     #[allow(clippy::too_many_lines)]
-    pub(crate) fn preprocess<S: AsRef<OsStr> + ?Sized>(
+    pub fn preprocess<S: AsRef<OsStr> + ?Sized>(
         module_path: &ModulePath,
         file_name: &S,
         input: &'input mut std::string::String,

--- a/tremor-script/src/lexer.rs
+++ b/tremor-script/src/lexer.rs
@@ -797,6 +797,7 @@ impl fmt::Display for CompilationUnit {
     }
 }
 
+/// Tracks set of included files in a given logical compilation unit
 pub struct IncludeStack {
     elements: Vec<CompilationUnit>,
     pub(crate) cus: Vec<CompilationUnit>,
@@ -815,10 +816,12 @@ impl IncludeStack {
         self.elements.pop();
     }
 
+    /// Returns set of compilation units
     pub fn into_cus(self) -> Vec<CompilationUnit> {
         self.cus
     }
 
+    /// Pushes a a compilation unit onto the include stack
     pub fn push<S: AsRef<OsStr> + ?Sized>(&mut self, file: &S) -> Result<usize> {
         let e = CompilationUnit::from_file(Path::new(file))?;
         if self.contains(&e) {
@@ -881,6 +884,7 @@ impl<'input> Preprocessor {
     }
 
     #[allow(clippy::too_many_lines)]
+    /// Preprocess a possibly nested set of related sources into a single compilation unit
     pub fn preprocess<S: AsRef<OsStr> + ?Sized>(
         module_path: &ModulePath,
         file_name: &S,

--- a/tremor-script/src/lib.rs
+++ b/tremor-script/src/lib.rs
@@ -56,6 +56,7 @@ pub mod prelude;
 pub mod query;
 /// Function registry
 pub mod registry;
+/// Tremor Script
 pub mod script;
 mod std_lib;
 mod tilde;

--- a/tremor-script/src/lib.rs
+++ b/tremor-script/src/lib.rs
@@ -56,7 +56,7 @@ pub mod prelude;
 pub mod query;
 /// Function registry
 pub mod registry;
-pub(crate) mod script;
+pub mod script;
 mod std_lib;
 mod tilde;
 /// Utility functions


### PR DESCRIPTION
Widen some `pub(crate)` declarations to `pub` so that tremor-script
is usable as a library independent of tremor runtime. Changes for v0.8
need to be made more visible to this end.