### PR TITLE
Make members of tremor script doc structs public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4452,7 +4452,7 @@ dependencies = [
 
 [[package]]
 name = "tremor-script"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "base64 0.12.1",
  "chrono",

--- a/tremor-script/Cargo.toml
+++ b/tremor-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tremor-script"
-version = "0.8.0"
+version = "0.8.1"
 description = "Tremor Script Interpreter"
 authors = ["The Tremor Team"]
 edition = "2018"

--- a/tremor-script/src/ast.rs
+++ b/tremor-script/src/ast.rs
@@ -149,9 +149,12 @@ struct Function<'script> {
 /// Documentaiton from constant
 #[derive(Debug, Clone, PartialEq)]
 pub struct ConstDoc<'script> {
-    name: Cow<'script, str>,
-    doc: Option<String>,
-    value_type: ValueType,
+    /// Constant name
+    pub name: Cow<'script, str>,
+    /// Constant documentation
+    pub doc: Option<String>,
+    /// Constant value type
+    pub value_type: ValueType,
 }
 
 impl<'script> ToString for ConstDoc<'script> {
@@ -174,17 +177,24 @@ impl<'script> ToString for ConstDoc<'script> {
 /// Documentaiton from function
 #[derive(Debug, Clone, PartialEq)]
 pub struct FnDoc<'script> {
-    name: Cow<'script, str>,
-    args: Vec<Cow<'script, str>>,
-    doc: Option<String>,
-    open: bool,
+    /// Function name
+    pub name: Cow<'script, str>,
+    /// Function arguments
+    pub args: Vec<Cow<'script, str>>,
+    /// Function documentation
+    pub doc: Option<String>,
+    /// Whether the function is open or not
+    // TODO clarify what open exactly is
+    pub open: bool,
 }
 
 /// Documentaiton from a module
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ModDoc<'script> {
-    name: Cow<'script, str>,
-    doc: Option<String>,
+    /// Module name
+    pub name: Cow<'script, str>,
+    /// Module documentation
+    pub doc: Option<String>,
 }
 
 impl<'script> ModDoc<'script> {

--- a/tremor-script/src/docs.rs
+++ b/tremor-script/src/docs.rs
@@ -14,8 +14,9 @@
 
 // Structs here are currently for use in tremor-language-server (where they are
 // dependencies for the build script as well as the package -- hence they are
-// bundled here for common use). These can be eventually utilized from tremor-script,
-// as part of structured documentation and automatic doc generation.
+// bundled here for common use). These can be eventually deprecated, once all
+// the functionality here is migrated to the ast doc structs (introduced in
+// v0.8).
 
 use std::fmt;
 
@@ -32,13 +33,11 @@ pub struct FunctionSignatureDoc {
 
 impl fmt::Display for FunctionSignatureDoc {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}({}) -> {}",
-            self.full_name,
-            self.args.join(", "),
-            self.result
-        )
+        let r = write!(f, "{}({})", self.full_name, self.args.join(", "));
+        if !self.result.is_empty() {
+            write!(f, " -> {}", self.result)?;
+        }
+        r
     }
 }
 


### PR DESCRIPTION
This is for use with tremor-language-server v0.8: https://github.com/wayfair-tremor/tremor-language-server/pull/33

Also improve display of function signature doc when info on return type is absent.