### PR TITLE
Skip query-exit integration test in CI due to intermittent non-reproducible failure

### DIFF
--- a/integration_testing/basic/query-exit.test/config
+++ b/integration_testing/basic/query-exit.test/config
@@ -1,1 +1,2 @@
 skip=0
+skip_ci=1


### PR DESCRIPTION
The test always passes locally on OSX and under Linux yet
fails almost 50% of the time for OSX and Linux in github CI.

Disabling in CI for now