### PR TITLE
Adds unit tests for more string functions in the Tremor std_lib

### DIFF
--- a/tremor-script/src/std_lib/string.rs
+++ b/tremor-script/src/std_lib/string.rs
@@ -171,7 +171,7 @@ pub fn load(registry: &mut Registry) {
 
 #[cfg(test)]
 mod test {
-    use crate::registry::fun;
+    use crate::registry::{fun, FunctionError};
     use simd_json::BorrowedValue as Value;
     macro_rules! assert_val {
         ($e:expr, $r:expr) => {
@@ -185,8 +185,13 @@ mod test {
         let v1 = Value::from("this is a test");
         let v2 = Value::from("test");
         let v3 = Value::from("cake");
+        assert_val!(f(&[&v1, &v2, &v3]), "this is a cake");
 
-        assert_val!(f(&[&v1, &v2, &v3]), "this is a cake")
+        let v1 = Value::from("this is a test with test present twice");
+        assert_val!(
+            f(&[&v1, &v2, &v3]),
+            "this is a cake with cake present twice"
+        );
     }
 
     #[test]
@@ -194,22 +199,52 @@ mod test {
         let f = fun("string", "is_empty");
         let v = Value::from("this is a test");
         assert_val!(f(&[&v]), false);
+
         let v = Value::from("");
-        assert_val!(f(&[&v]), true)
+        assert_val!(f(&[&v]), true);
     }
 
     #[test]
     fn len() {
         let f = fun("string", "len");
+
+        let v = Value::from("");
+        assert_val!(f(&[&v]), 0);
+
         let v = Value::from("this is a test");
-        assert_val!(f(&[&v]), 14)
+        assert_val!(f(&[&v]), 14);
+
+        let v = Value::from("this is another test ♥");
+        assert_val!(f(&[&v]), 22);
+    }
+
+    #[test]
+    fn bytes() {
+        let f = fun("string", "bytes");
+
+        let v = Value::from("");
+        assert_val!(f(&[&v]), 0);
+
+        let v = Value::from("this is a test");
+        assert_val!(f(&[&v]), 14);
+
+        let v = Value::from("this is another test ♥");
+        assert_val!(f(&[&v]), 24);
     }
 
     #[test]
     fn trim() {
         let f = fun("string", "trim");
+
+        let v = Value::from("   ");
+        assert_val!(f(&[&v]), "");
+
         let v = Value::from(" this is a test ");
-        assert_val!(f(&[&v]), "this is a test")
+        assert_val!(f(&[&v]), "this is a test");
+
+        // Non-breaking spaces, i.e., non-ASCII whitespace
+        let v = Value::from("\u{00A0}\u{00A0}this is a test\u{00A0}\u{00A0}");
+        assert_val!(f(&[&v]), "this is a test");
     }
 
     #[test]
@@ -283,5 +318,43 @@ mod test {
         let v1 = Value::from("snot badger");
         let v2 = Value::from("snot badger");
         assert_val!(f(&[&v1, &v2]), Value::from(true));
+    }
+
+    #[test]
+    fn format() {
+        let f = fun("string", "format");
+        let v1 = Value::from("a string with {}");
+        let v2 = Value::from("more text");
+        let v3 = Value::from(123);
+        assert_val!(f(&[&v1, &v2]), Value::from("a string with more text"));
+        assert_val!(f(&[&v1, &v3]), Value::from("a string with 123"));
+
+        // Format string missing
+        match f(&[&v3]) {
+            Err(FunctionError::RuntimeError { error, .. }) => {
+                assert_eq!(error, "expected 1st parameter to format to be a format specifier e.g. to print a number use `string::format(\"{}\", 1)`");
+            }
+            // ALLOW: panicking is the idiomatic way to signal failure in tests
+            _any_other_result => panic!("Call should have failed: format string missing"),
+        }
+
+        // Too few arguments for format string
+        // TODO: this error message isn't as helpful as it could be
+        match f(&[&v1]) {
+            Err(FunctionError::RuntimeError { error, .. }) => {
+                assert_eq!(error, "the arguments passed to the format function are less than the `{}` specifiers in the format string. The placeholder at 14 can not be filled");
+            }
+            // ALLOW: panicking is the idiomatic way to signal failure in tests
+            _any_other_result => panic!("Call should have failed: too few arguments provided"),
+        }
+
+        // Too many arguments for format string
+        match f(&[&v1, &v2, &v3]) {
+            Err(FunctionError::RuntimeError { error, .. }) => {
+                assert_eq!(error, "too many parameters passed. Ensure that you have the same number of {} in your format string");
+            }
+            // ALLOW: panicking is the idiomatic way to signal failure in tests
+            _any_other_result => panic!("Call should have failed: too many arguments provided"),
+        }
     }
 }


### PR DESCRIPTION
Of special interest for review: I use explicit `panic`s for failure cases in the tests which aren't easily handled by `assert`/`assert_eq`. I added an `ALLOW`-comment to each case. I think that the checks registered as GitHub actions in this repo allow `panic` in test modules even without `ALLOW`-comment. Should I keep them, remove them, remove the panics, ...?