### PR TITLE
Use rust-toolchain file for all github workflows

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -31,8 +31,9 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
           override: true
+          profile: minimal
+          components: rustfmt
       - name: Check Formating
         run: cargo fmt --all -- --check
   clippy-check:
@@ -41,7 +42,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Install deps
         run: sudo apt-get install -y libssl1.0-dev libssl1.0
-      # picks up the rust-toolchain file in the project
       - uses: actions-rs/toolchain@v1
         with:
           override: true

--- a/.github/workflows/eqc.yaml
+++ b/.github/workflows/eqc.yaml
@@ -22,8 +22,8 @@ jobs:
         run: ~/go/bin/yaml2json < static/openapi.yaml > static/openapi.json
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
           override: true
+          profile: minimal
       - name: Build
         run: cargo build -p tremor-server -p tremor-tool
       - name: Run eqc tests

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -18,8 +18,8 @@ jobs:
         run: sudo apt-get install -y libssl1.0-dev libssl1.0
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
           override: true
+          profile: minimal
       - name: Build
         run: cargo build -p tremor-server -p tremor-tool
       - name: Run Integration Tests
@@ -41,8 +41,8 @@ jobs:
         run: go get github.com/landoop/coyote
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
           override: true
+          profile: minimal
       - name: Build
         run: cargo build -p tremor-server -p tremor-tool
       - name: Run curl tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,8 @@ jobs:
         run: sudo apt-get install -y libssl1.0-dev libssl1.0
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
           override: true
+          profile: minimal
       # - uses: actions/cache@v1
       #   id: cache-build
       #   with:
@@ -46,8 +46,8 @@ jobs:
         run: sudo apt-get install -y libssl1.0-dev libssl1.0
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
           override: true
+          profile: minimal
       # - uses: actions/cache@v1
       #   id: cache-build
       #   with:


### PR DESCRIPTION
Also use the minimial profile for rustup install. Should speed up the CI a bit

Fixes https://github.com/wayfair-tremor/tremor-runtime/issues/277.