### PR TITLE
fix for Influx codec decode to stop scanning the input string after reaching the end of it

### DIFF
--- a/tremor-influx/src/decoder.rs
+++ b/tremor-influx/src/decoder.rs
@@ -274,9 +274,12 @@ where
             if !input.starts_with(search) {
                 res.push('\\');
             }
-            res.push_str(&input[..1]);
 
-            input = &input[1..];
+            if !input.is_empty() {
+                res.push_str(&input[..1]);
+                input = &input[1..];
+            }
+
             parse_to_complex(total_idx, res, idx + 2, input, p)
         } else {
             Ok((data.into(), idx))
@@ -309,8 +312,10 @@ where
                 if !input.starts_with(search) {
                     res.push('\\');
                 }
-                res.push_str(&input[..1]);
-                input = &input[1..];
+                if !input.is_empty() {
+                    res.push_str(&input[..1]);
+                    input = &input[1..];
+                }
                 offset += 2;
             } else {
                 res.push_str(&data);


### PR DESCRIPTION
This fix is to stop Tremor from panicking at Influx codec decode while there are odd number of escape characters '\'  at the end of an input string . This fixes https://github.com/wayfair-tremor/tremor-runtime/issues/294. 
