### PR TITLE
Support rpm packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /target*
 */target*
 **/*.rs.bk
-.rpm
 /window/target*
 /property_testing/target
 local-examples

--- a/.rpm/tremor.spec
+++ b/.rpm/tremor.spec
@@ -1,0 +1,146 @@
+# RPM spec file meant for packaging via cargo-rpm
+#
+# initially generated with `cargo rpm init` and then (heavily) modified for
+# our use.
+
+%define __spec_install_post %{nil}
+%define __os_install_post %{_dbpath}/brp-compress
+%define debug_package %{nil}
+
+# if the _unitdir macro is not defined, set it to the standard systemd unit path
+%{!?_unitdir: %define _unitdir /usr/lib/systemd/system}
+
+###############################################################################
+
+# the @@ strings here will be replaced with meaningful values when the build
+# is done via cargo-rpm
+Name: tremor
+Summary: Tremor is an early stage event processing system for unstructured data with rich support for structural pattern matching, filtering and transformation.
+Version: @@VERSION@@
+Release: @@RELEASE@@%{?dist}
+License: ASL 2.0
+Group: System Environment/Daemons
+Source0: %{name}-%{version}.tar.gz
+URL: https://www.tremor.rs
+
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+
+###############################################################################
+
+%if 0%{?centos}
+# ensures systemd_* macros are available for use in rpm scripts (as in %post)
+BuildRequires: systemd
+%endif
+
+# TODO make sure our package works on glibc 2.17 (for centos 7 support) for x86_64.
+# the binary is built on image tremorproject/tremor-builder:x86_64-unknown-linux-gnu,
+# (debian buster) which has glibc 2.28, so will probably need to try from older images
+# with older glibc (and still ensure that tremor compiles there).
+Requires: glibc >= 2.18
+# TODO link to these statically?
+# via snmalloc
+Requires: libstdc++
+Requires: libatomic
+# via surf
+Requires: libcurl
+# via surf and rdkafka. provides libz
+Requires: zlib
+# via xz2 (in tremor-script). provides liblzma
+Requires: xz
+
+# for user/group creation
+Requires(post): shadow-utils
+
+Requires(post): systemd
+Requires(preun): systemd
+Requires(postun): systemd
+
+###############################################################################
+
+%description
+%{summary}
+
+%prep
+%setup -q
+
+%build
+# we rely on binaries pre-built alrady in the Source0 tar file
+# so this section is empty for us.
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}
+cp -a * %{buildroot}
+#tree %{_topdir} # only for debugging
+
+%clean
+rm -rf %{buildroot}
+
+###############################################################################
+
+%post
+# create user/group for our use. based on:
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/UsersAndGroups/#_dynamic_allocation
+getent group tremor >/dev/null || groupadd -r tremor
+getent passwd tremor >/dev/null || \
+  useradd -r -g tremor -d / -s /sbin/nologin \
+  -c "Tremor" tremor
+
+# create the log dir
+mkdir -p %{_localstatedir}/log/%{name}
+chown -R tremor:tremor %{_localstatedir}/log/%{name}
+
+# systemd setup
+%if 0%{?centos}
+%systemd_post tremor.service
+%else
+# contents of systemd_post macro from centos7.7
+if [ $1 -eq 1 ] ; then
+  # Initial installation
+  systemctl preset tremor.service >/dev/null 2>&1 || :
+fi
+%endif
+
+###############################################################################
+
+%preun
+%if 0%{?centos}
+%systemd_preun tremor.service
+%else
+# contents of systemd_preun macro from centos7.7
+if [ $1 -eq 0 ] ; then
+  # Package removal, not upgrade
+  systemctl --no-reload disable tremor.service > /dev/null 2>&1 || :
+  systemctl stop %{?*} > /dev/null 2>&1 || :
+fi
+%endif
+
+%postun
+%if 0%{?centos}
+%systemd_postun_with_restart tremor.service
+%else
+# contents of systemd_postun macro from centos7.7
+systemctl daemon-reload >/dev/null 2>&1 || :
+if [ $1 -ge 1 ] ; then
+  # Package upgrade, not uninstall
+  systemctl try-restart tremor.service >/dev/null 2>&1 || :
+fi
+%endif
+
+###############################################################################
+
+%files
+%defattr(-,root,root,-)
+
+# the dir macros used here should line up with path names that are part of
+# package.metadata.rpm.files configuration in the project's cargo manifest
+
+%{_bindir}/*
+
+%doc %{_datadir}/doc/%{name}/README.md
+%license %{_datadir}/licenses/%{name}/LICENSE
+
+%config(noreplace) %{_sysconfdir}/%{name}/logger.yaml
+%config %{_sysconfdir}/%{name}/config/*
+
+%{_unitdir}/tremor.service

--- a/.rpm/tremor.spec
+++ b/.rpm/tremor.spec
@@ -143,4 +143,7 @@ fi
 %config(noreplace) %{_sysconfdir}/%{name}/logger.yaml
 %config %{_sysconfdir}/%{name}/config/*
 
+%dir %{_usr}/lib/tremor-script/
+%{_usr}/lib/tremor-script/*
+
 %{_unitdir}/tremor.service

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,10 @@ assets = [
   ["packaging/distribution/etc/tremor/config/*", "/etc/tremor/config/", "644"],
   # TODO enable this after some example cleanup
   #["demo/examples/*", "/etc/tremor/config/examples/", "644"],
+  # TODO ideally, we should need to copy only the root tremor-script/lib directory
+  ["tremor-script/lib/*", "/usr/lib/tremor-script/", "644"],
+  ["tremor-script/lib/std/*", "/usr/lib/tremor-script/std/", "644"],
+  ["tremor-script/lib/tremor/*", "/usr/lib/tremor-script/tremor/", "644"],
   # copying systemd service to standard location for debian packages
   ["packaging/distribution/etc/systemd/system/*", "/lib/systemd/system/", "644"],
 ]
@@ -169,5 +173,6 @@ tremor-server = { path = "/usr/bin/tremor-server" }
 "../packaging/distribution/etc/tremor/" = { path = "/etc/tremor/" }
 # TODO enable this after some example cleanup
 #"../demo/examples/" = { path = "/etc/tremor/config/examples/" }
+"../tremor-script/lib/" = { path = "/usr/lib/tremor-script/" }
 # copying systemd service to standard location for rpm packages
 "../packaging/distribution/etc/systemd/system/tremor.service" = { path = "/usr/lib/systemd/system/tremor.service" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,21 +122,22 @@ gcp = [ "google-storage1", "google-pubsub1", "hyper-rustls", "yup-oauth2", "hype
 # for use during debian packaging, via cargo-deb
 # https://github.com/mmstick/cargo-deb#packagemetadatadeb-options
 [package.metadata.deb]
-name = "tremor-server"
+name = "tremor"
 section = "net"
 depends = "$auto"
-maintainer-scripts = "distribution/debian/maintainer-scripts/"
+maintainer-scripts = "packaging/distribution/debian/maintainer-scripts/"
 assets = [
   # target path will be automatically corrected when cross-compiling
-  ["target/release/tremor-server", "usr/bin/", "755"],
-  ["README.md", "usr/share/doc/tremor/", "644"],
-  ["LICENSE", "usr/share/doc/tremor/", "644"],
+  ["target/release/tremor-server", "/usr/bin/", "755"],
+  ["README.md", "/usr/share/doc/tremor/", "644"],
+  ["LICENSE", "/usr/share/doc/tremor/", "644"],
   # need to specify each directory contents since only actual file entries are allowed here
   ["packaging/distribution/etc/tremor/*", "/etc/tremor/", "644"],
   ["packaging/distribution/etc/tremor/config/*", "/etc/tremor/config/", "644"],
   # TODO enable this after some example cleanup
   #["demo/examples/*", "/etc/tremor/config/examples/", "644"],
-  ["packaging/distribution/etc/systemd/system/*", "/etc/systemd/system/", "644"],
+  # copying systemd service to standard location for debian packages
+  ["packaging/distribution/etc/systemd/system/*", "/lib/systemd/system/", "644"],
 ]
 conf-files = [
   # these files won't be overwritten when the package is upgraded

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,3 +148,26 @@ conf-files = [
 extended-description = """\
 Tremor is an early stage event processing system for unstructured data with rich support for structural pattern matching, filtering and transformation.
 """
+
+# for use during rpm packaging, via cargo-rpm
+# https://github.com/iqlusioninc/cargo-rpm
+[package.metadata.rpm]
+package = "tremor"
+[package.metadata.rpm.cargo]
+# useful when using cargo rpm itself to build the project (i.e. without the
+# --no-cargo-build flag from `cargo rpm build`)
+buildflags = ["--release"]
+profile = "release"
+[package.metadata.rpm.targets]
+tremor-server = { path = "/usr/bin/tremor-server" }
+# The LHS paths here are relative to the rpm config dir (.rpm at project root).
+# If you add new files here, please make sure to add them to %files section in
+# the rpm spec file (inside .rpm) -- otherwise the rpm packaging will fail.
+[package.metadata.rpm.files]
+"../README.md" = { path = "/usr/share/doc/tremor/README.md" }
+"../LICENSE" = { path = "/usr/share/licenses/tremor/LICENSE" }
+"../packaging/distribution/etc/tremor/" = { path = "/etc/tremor/" }
+# TODO enable this after some example cleanup
+#"../demo/examples/" = { path = "/etc/tremor/config/examples/" }
+# copying systemd service to standard location for rpm packages
+"../packaging/distribution/etc/systemd/system/tremor.service" = { path = "/usr/lib/systemd/system/tremor.service" }

--- a/Cross.toml
+++ b/Cross.toml
@@ -27,10 +27,8 @@ passthrough = [
 # linking issues seen here.
 image = "tremorproject/tremor-builder:x86_64-unknown-linux-musl"
 
-# cross here is expected to be installed via:
-#   cargo install --git https://github.com/anupdhml/cross.git --branch custom_target_fixes
-# has fixes for this custom target to work. PR tracking the upstream merge:
-#   https://github.com/rust-embedded/cross/pull/431
+# cross here is expected to be installed via (has fixes for this custom target to work):
+#   cargo install --git https://github.com/rust-embedded/cross.git
 [target.x86_64-alpine-linux-musl]
 xargo = false # cross uses xargo for non-standard targets normally, but we don't want that here
 # the before-mentioned linking issues (with x86_64-unknown-linux-musl) don't occur here,

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ RELEASE_TARGETS := \
 # fully static binaries (for easier distribution), but we are seeing up to
 # 25% slowdown for some of our benchmarks with musl builds. So we stick with
 # gnu builds for now.
-RELEASE_FORMATS_x86_64-unknown-linux-gnu := archive,deb
+RELEASE_FORMATS_x86_64-unknown-linux-gnu := archive,deb,rpm
 RELEASE_FORMATS_x86_64-alpine-linux-musl := archive
 #RELEASE_FORMATS_x86_64-unknown-linux-musl := archive
 

--- a/packaging/builder-images/README.md
+++ b/packaging/builder-images/README.md
@@ -2,8 +2,7 @@
 
 Docker images meant to be used for compilation across various targets (eg: as part of CI builds during testing of individual commits/PRs, or to produce the final release artifacts). Works well with [cross](https://github.com/rust-embedded/cross), but can be used independent of it too.
 
-We publish these images to [dockerhub](https://hub.docker.com/r/tremorproject/tremor-builder/tags), and they get picked up via [cross configuratio
-n](../../Cross.toml) file at project root, during builds (cross automatically pulls them if not already present). So unless you are making changes to the files here, you won't need to build these images locally.
+We publish these images to [dockerhub](https://hub.docker.com/r/tremorproject/tremor-builder/tags), and they get picked up via [cross configuration](../../Cross.toml) file at project root, during builds (cross automatically pulls them if not already present). So unless you are making changes to the files here, you won't need to build these images locally.
 
 ## Modifications
 

--- a/packaging/builder-images/build_image.sh
+++ b/packaging/builder-images/build_image.sh
@@ -6,8 +6,8 @@
 #
 # Meant to be run from the same directory as the script
 #
-# Usage: ./build_image.sh TARGET
-# Example: ./build_image.sh x86_64-unknown-linux-gnu
+# Usage: build_image.sh TARGET
+# Example: build_image.sh x86_64-unknown-linux-gnu
 
 # exit the script when a command fails
 set -o errexit

--- a/packaging/cross_build.sh
+++ b/packaging/cross_build.sh
@@ -44,15 +44,20 @@ pushd "$ROOT_DIR" > /dev/null
 # install cross if not already there (helps us build easily across various targets)
 # see https://github.com/rust-embedded/cross
 #
-# currently need to install it from a personal fork for builds to work against custom targets
+# currently need to install it from the git repo for builds to work against custom targets
 # (eg: x86_64-alpine-linux-musl which we use for generating working musl binaries right now)
-# once https://github.com/rust-embedded/cross/pull/431 is merged, we can install it from upstream.
+# once version > 0.20 is released, install it from crates.io. changes from the development
+# repo that we make use of here: https://github.com/rust-embedded/cross/pull/431
 if ! command -v cross > /dev/null 2>&1; then
   echo "Installing cross..."
-  cargo install --git https://github.com/anupdhml/cross.git --branch custom_target_fixes
+  cargo install --git https://github.com/rust-embedded/cross.git
 fi
 
-BUILD_ARGS=("--target" "$TARGET")
+# locked flag is good for reproducible builds -- ensures that Cargo.lock is
+# always up-to-date (i.e. build will error out if it needs an update). This
+# also means it catches situations where we update versions in Cargo.toml
+# but forget to update Cargo.lock.
+BUILD_ARGS=("--target" "$TARGET" --locked)
 
 CUSTOM_RUSTFLAGS=()
 RUSTC_TARGET_FEATURES=()

--- a/packaging/distribution/etc/systemd/system/tremor.service
+++ b/packaging/distribution/etc/systemd/system/tremor.service
@@ -10,6 +10,7 @@ Group=tremor
 ExecStart=/usr/bin/tremor-server --logger-config /etc/tremor/logger.yaml
 Restart=always
 SyslogIdentifier=tremor
+Environment="TREMOR_PATH=/usr/lib/tremor-script"
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/distribution/etc/systemd/system/tremor.service
+++ b/packaging/distribution/etc/systemd/system/tremor.service
@@ -9,6 +9,7 @@ User=tremor
 Group=tremor
 ExecStart=/usr/bin/tremor-server --logger-config /etc/tremor/logger.yaml
 Restart=always
+SyslogIdentifier=tremor
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/distribution/etc/tremor/config/main.yaml.sample
+++ b/packaging/distribution/etc/tremor/config/main.yaml.sample
@@ -12,9 +12,9 @@ pipeline:
         - in
       outputs:
         - out
-        - outliers
+        - error
     nodes:
-      - id: r
+      - id: runtime
         op: runtime::tremor
         config:
           script: |
@@ -22,14 +22,18 @@ pipeline:
             let event.hostname = system::hostname();
             event
     links:
-      in: [ r ]
-      r: [ out ]
+      in: [ runtime ]
+      runtime: [ out ]
+      runtime/error: [ error ]
 
 binding:
   - id: default
     links:
       '/onramp/metronome/{instance}/out': [ '/pipeline/main/{instance}/in' ]
       '/pipeline/main/{instance}/out': [ '/offramp/system::stdout/system/in' ]
+      '/pipeline/main/{instance}/error': [ '/offramp/system::stderr/system/in' ]
+
+      # tremor metrics
       '/pipeline/system::metrics/system/out': [ '/offramp/system::stdout/system/in' ]
 mapping:
   /binding/default/01:

--- a/packaging/functions.sh
+++ b/packaging/functions.sh
@@ -24,7 +24,7 @@ function package_archive {
   echo "Copying files to temporary archive directory: ${temp_archive_dir}"
 
   # main binary
-  mkdir -p "$temp_archive_dir/bin"
+  mkdir -p "${temp_archive_dir}/bin"
   cp -v "$TARGET_BIN" "${temp_archive_dir}/bin"
 
   # support files
@@ -32,6 +32,11 @@ function package_archive {
   cp -vR "${ROOT_DIR}/packaging/distribution/etc/" "${temp_archive_dir}/"
   # TODO enable this after some example cleanup
   #cp -vR "${ROOT_DIR}/demo/examples/" "${temp_archive_dir}/etc/tremor/config/"
+
+  # tremor-script lib
+  # TREMOR_PATH needs to be set to wherever this folder gets extracted to
+  mkdir -p "${temp_archive_dir}/lib"
+  cp -vR "${ROOT_DIR}/tremor-script/lib/" "${temp_archive_dir}/lib/tremor-script/"
 
   echo "Creating archive file: ${archive_file}"
   tar czf $archive_file -C "$TARGET_BUILD_DIR" "$archive_name"

--- a/packaging/run.sh
+++ b/packaging/run.sh
@@ -28,7 +28,7 @@ set -o errexit
 # catch exit status for piped commands
 set -o pipefail
 
-SUPPORTED_FORMATS="archive,deb"
+SUPPORTED_FORMATS="archive,deb,rpm"
 
 function print_help {
     cat <<EOF
@@ -125,6 +125,9 @@ for format in ${FORMATS//,/ }; do
         ;;
       deb)
         package_deb
+        ;;
+      rpm)
+        package_rpm
         ;;
       *)
         echo "Unknown package format '${format}'"

--- a/packaging/run.sh
+++ b/packaging/run.sh
@@ -69,11 +69,11 @@ if [ -z "$FORMATS" ]; then
   FORMATS="$SUPPORTED_FORMATS"
 fi
 
-BIN_NAME="tremor-server"
+PACKAGE_NAME="tremor"
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 
-echo "Packaging ${BIN_NAME} for target ${TARGET} in ${FORMATS} formats, from ${ROOT_DIR}"
+echo "Packaging ${PACKAGE_NAME} for target ${TARGET} in ${FORMATS} formats, from ${ROOT_DIR}"
 
 # this move allows us to run this script from anywhere in the repo
 pushd "$ROOT_DIR" > /dev/null
@@ -81,7 +81,7 @@ pushd "$ROOT_DIR" > /dev/null
 ###############################################################################
 
 TARGET_BUILD_DIR="${ROOT_DIR}/target/${TARGET}/release" # we always package for release builds
-TARGET_BIN="$TARGET_BUILD_DIR/${BIN_NAME}"
+TARGET_BIN="${TARGET_BUILD_DIR}/tremor-server"
 
 # assumes that the build's been done first
 if [ ! -f "$TARGET_BIN" ]; then
@@ -95,7 +95,7 @@ echo "Found the target binary: ${TARGET_BIN}"
 # the regex match pattern here is the package version, which is true for most packages)
 VERSION=$(grep --max-count 1 '^version\s*=' Cargo.toml | cut --delimiter '=' -f2 | tr --delete ' ' | tr --delete '"' || true)
 #
-# accurate determination, but depends on remarshal which won't be availale by default
+# accurate determination, but depends on remarshal which won't be available by default
 #VERSION=$(remarshal -i Cargo.toml -of json | jq -r '.package.version')
 
 if [ -z "$VERSION" ]; then


### PR DESCRIPTION
Resolves https://github.com/wayfair-tremor/tremor-runtime/issues/279 mostly.

The generated rpm does not work on centos 7 currently (works on 8 though) because centos 7 has glibc 2.17 and our image for docker build here (debian buster) has newer glibc. Will fix this in a later PR (need to go with older debian versions for the image, but still ensure that tremor compiles there -- currently, older images cause issues for dependencies like snmalloc).

cargo-rpm functionality here relies on these upstream PRs: https://github.com/iqlusioninc/cargo-rpm/pulls?q=is%3Apr+is%3Aclosed+author%3Aanupdhml

---

Also adds tremor-script lib to the current package set (archive,deb,rpm) so that scripts using tremor-script stdlib work for the packaged tremor.

Other packaging-related cleanups here:

```
* Change package names to be tremor (from tremor-server)
* Fix discovery of debian maintainer-scripts during deb generation
* Change systemd service path to standard location for debian packages
* Ensure tremor as syslog program name for systemd service log output
* Cleanup references to cross fork now that upstream PR is merged
* Add --locked flag during cross building
* Print package details after packaging
* Make packaging output less verbose for improved readability
* Minor doc cleanups
```