### PR TITLE
Standardize tremor script lib path for packages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ grcov
 .dockerignore
 perf.*
 temp
+packaging/out/

--- a/.rpm/tremor.spec
+++ b/.rpm/tremor.spec
@@ -143,7 +143,7 @@ fi
 %config(noreplace) %{_sysconfdir}/%{name}/logger.yaml
 %config %{_sysconfdir}/%{name}/config/*
 
-%dir %{_usr}/lib/tremor-script/
-%{_usr}/lib/tremor-script/*
+%dir %{_usr}/lib/tremor
+%{_usr}/lib/tremor/*
 
 %{_unitdir}/tremor.service

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,9 +137,9 @@ assets = [
   # TODO enable this after some example cleanup
   #["demo/examples/*", "/etc/tremor/config/examples/", "644"],
   # TODO ideally, we should need to copy only the root tremor-script/lib directory
-  ["tremor-script/lib/*", "/usr/lib/tremor-script/", "644"],
-  ["tremor-script/lib/std/*", "/usr/lib/tremor-script/std/", "644"],
-  ["tremor-script/lib/tremor/*", "/usr/lib/tremor-script/tremor/", "644"],
+  ["tremor-script/lib/*", "/usr/lib/tremor/tremor-script/", "644"],
+  ["tremor-script/lib/std/*", "/usr/lib/tremor/tremor-script/std/", "644"],
+  ["tremor-script/lib/tremor/*", "/usr/lib/tremor/tremor-script/tremor/", "644"],
   # copying systemd service to standard location for debian packages
   ["packaging/distribution/etc/systemd/system/*", "/lib/systemd/system/", "644"],
 ]
@@ -173,6 +173,6 @@ tremor-server = { path = "/usr/bin/tremor-server" }
 "../packaging/distribution/etc/tremor/" = { path = "/etc/tremor/" }
 # TODO enable this after some example cleanup
 #"../demo/examples/" = { path = "/etc/tremor/config/examples/" }
-"../tremor-script/lib/" = { path = "/usr/lib/tremor-script/" }
+"../tremor-script/lib/" = { path = "/usr/lib/tremor/tremor-script/" }
 # copying systemd service to standard location for rpm packages
 "../packaging/distribution/etc/systemd/system/tremor.service" = { path = "/usr/lib/systemd/system/tremor.service" }

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -39,6 +39,7 @@ If you need to build the docker images used during the cross build process, plea
 * cargo
 * docker
 * dpkg, ldd (optionally, to auto-infer dynamic lib dependencies during debian packaging, via [cargo-deb](https://github.com/mmstick/cargo-deb#installation))
+* rpmbuild (for building rpms, via [cargo-rpm](https://github.com/iqlusioninc/cargo-rpm.git))
 
 The setup here was tested successfully from linux (ubuntu) environments, but it should work well in other environments too, as long as the above requirements are met.
 

--- a/packaging/distribution/etc/systemd/system/tremor.service
+++ b/packaging/distribution/etc/systemd/system/tremor.service
@@ -10,7 +10,6 @@ Group=tremor
 ExecStart=/usr/bin/tremor-server --logger-config /etc/tremor/logger.yaml
 Restart=always
 SyslogIdentifier=tremor
-Environment="TREMOR_PATH=/usr/lib/tremor-script"
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/functions.sh
+++ b/packaging/functions.sh
@@ -35,8 +35,8 @@ function package_archive {
 
   # tremor-script lib
   # TREMOR_PATH needs to be set to wherever this folder gets extracted to
-  mkdir -p "${temp_archive_dir}/lib"
-  cp -vR "${ROOT_DIR}/tremor-script/lib/" "${temp_archive_dir}/lib/tremor-script/"
+  mkdir -p "${temp_archive_dir}/lib/tremor"
+  cp -vR "${ROOT_DIR}/tremor-script/lib/" "${temp_archive_dir}/lib/tremor/tremor-script/"
 
   echo "Creating archive file: ${archive_file}"
   tar czf $archive_file -C "$TARGET_BUILD_DIR" "$archive_name"

--- a/tremor-script/src/path.rs
+++ b/tremor-script/src/path.rs
@@ -53,7 +53,8 @@ impl ModulePath {
     /// Load module path
     pub fn load() -> Self {
         load_(
-            &std::env::var("TREMOR_PATH").unwrap_or_else(|_| String::from("/opt/local/tremor/lib")),
+            &std::env::var("TREMOR_PATH")
+                .unwrap_or_else(|_| String::from("/usr/lib/tremor/tremor-script")),
         )
     }
 }


### PR DESCRIPTION
Use tremor-script lib from `/usr/lib/tremor/tremor-script`, when `TREMOR_PATH` is not set. Follow-up to https://github.com/wayfair-tremor/tremor-runtime/commit/0d1009838840cb6d932b6e0573bc29830f4adbb5

This is similar to how we are now picking up configs from `/etc/tremor` by default now: https://github.com/wayfair-tremor/tremor-runtime/commit/c36dd2247fa7d54b1b08e438c73929947d60dafe

Useful for running tremor from our packages.

---

Also some minor cleanup as a followup to https://github.com/wayfair-tremor/tremor-runtime/pull/307.