### PR TITLE
Update ci and docker build

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
 [build]
-rustflags = ["-C", "target-feature=+avx,+avx2,+sse4.2"]
+rustflags = ["-C", "target-cpu=native"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
 [build]
-rustflags = ["-C", "target-cpu=native"]
+rustflags = ["-C", "target-feature=+avx,+avx2,+sse4.2"]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,8 +74,8 @@ jobs:
         env:
           RUSTFLAGS: -C target-cpu=native
         with:
-          version: '0.11.0'
-          args: '--out Xml --exclude-files target* --exclude-files depricated/* --all'
+          version: "0.13.4"
+          args: "--out Xml --exclude-files target* --exclude-files depricated/* --all"
       - uses: codecov/codecov-action@v1.0.2
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,8 +74,8 @@ jobs:
         env:
           RUSTFLAGS: -C target-cpu=native
         with:
-          version: "0.13.4"
-          args: "--out Xml --exclude-files target* --exclude-files depricated/* --all"
+          version: "0.13.3"
+          args: " --exclude-files target* --all"
       - uses: codecov/codecov-action@v1.0.2
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest as builder
+FROM rust:1.43.1 as builder
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -29,7 +29,8 @@ COPY tremor-query ./tremor-query
 COPY tremor-server ./tremor-server
 COPY tremor-tool ./tremor-tool
 
-RUN cargo build --release --all
+RUN cat /proc/cpuinfo
+RUN cargo build --release --all --verbose
 
 FROM debian:buster-slim
 


### PR DESCRIPTION
* update to a newer tarpaulin
* update docker build to be more verbose
* ~update .cargo/config to always use CPU features, not target-CPU (this should prevent non-copyable builds)~ CI says no :(
* pin the rust version for the docker image