### PR TITLE
Source rust-rdkafka from github repo for some kafka fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,9 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca565a7df06f3d4b485494f25ba05da1435950f4dc263440eda7a6fa9b8e36e4"
+checksum = "5f1e2d7c9c4282839fc56f549bc006a54e6f28a851a7de7adcf3f50575751760"
 dependencies = [
  "derivative",
  "num_enum_derive",
@@ -2510,9 +2510,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
+checksum = "4a9f19dafa80d8af21ede328f2c4ed836604a2eb1c309d688f89a7cc40568923"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.10",
@@ -3166,8 +3166,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d455ac2a07a27d87b4f0e321dfd8d9a5b574bd96f55e42e6c594712a08051222"
+source = "git+https://github.com/fede1024/rust-rdkafka?rev=a73bbae27361073e9370a4c9b8d5029313d1e9e2#a73bbae27361073e9370a4c9b8d5029313d1e9e2"
 dependencies = [
  "futures 0.3.4",
  "libc",
@@ -3176,13 +3175,13 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "tokio 0.2.18",
 ]
 
 [[package]]
 name = "rdkafka-sys"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d770343fbbc6089c750000711a17a906e8b3f7831afcd752d9667d38833e578"
+version = "2.0.0+1.4.2"
+source = "git+https://github.com/fede1024/rust-rdkafka?rev=a73bbae27361073e9370a4c9b8d5029313d1e9e2#a73bbae27361073e9370a4c9b8d5029313d1e9e2"
 dependencies = [
  "cmake",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,10 @@ postgres-protocol = "0.5"
 tokio-postgres = "0.5"
 
 # kafka. cmake is the encouraged way to build this and also the one that works on windows.
-rdkafka = { version = "0.23", features = ["cmake-build"] }
+#rdkafka = { version = "0.23", features = ["cmake-build"] }
+# sourcing from git to get the fix in https://github.com/fede1024/rust-rdkafka/pull/259
+# remove once version 0.24 is released
+rdkafka = { git = "https://github.com/fede1024/rust-rdkafka", rev = "a73bbae27361073e9370a4c9b8d5029313d1e9e2", features = ["cmake-build"] }
 
 # crononome
 cron = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,10 +79,7 @@ postgres-protocol = "0.5"
 tokio-postgres = "0.5"
 
 # kafka. cmake is the encouraged way to build this and also the one that works on windows.
-#rdkafka = { version = "0.23", features = ["cmake-build"] }
-# sourcing from git to get the fix in https://github.com/fede1024/rust-rdkafka/pull/259
-# remove once version 0.24 is released
-rdkafka = { git = "https://github.com/fede1024/rust-rdkafka", rev = "a73bbae27361073e9370a4c9b8d5029313d1e9e2", features = ["cmake-build"] }
+rdkafka = { version = "0.23", features = ["cmake-build"] }
 
 # crononome
 cron = "0.6.0"
@@ -117,4 +114,6 @@ default = []
 gpc = [ "google-storage1", "google-pubsub1", "hyper-rustls", "yup-oauth2", "hyper" ]
 
 [patch.crates-io]
-#  waiting for https://github.com/http-rs/tide/pull/408
+# sourcing from git to get the fix in https://github.com/fede1024/rust-rdkafka/pull/259
+# remove once version 0.24 is released
+rdkafka = { git = "https://github.com/fede1024/rust-rdkafka", rev = "a73bbae27361073e9370a4c9b8d5029313d1e9e2", features = ["cmake-build"] }


### PR DESCRIPTION
Incorporates fixes from https://github.com/fede1024/rust-rdkafka/pull/259, in an attempt to address kafka produce issues we see under high-load. 