### PR TITLE
Neon (aarch64) support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,9 @@ env_logger = "0.7"
 [features]
 default = []
 
+# arm suopport
+neon = [ "simd-json/neon" ]
+
 # Experimental suport for google cloud APIs
 gcp = [ "google-storage1", "google-pubsub1", "hyper-rustls", "yup-oauth2", "hyper" ]
 

--- a/README.md
+++ b/README.md
@@ -193,3 +193,11 @@ To execute a benchmark, build tremor in **release** mode and run the examples fr
 ```bash
 ./bench/run <name>
 ```
+
+### ARM/aarch64/NEON
+
+to run and compile with neon use:
+
+```bash
+RUSTCFLAGS="-C cpu-target=native" cargo +nightly build --features neon --all
+```


### PR DESCRIPTION
Support for aarch64 / neon based systems.

To compile / run this requires:
```
RUSTCFLAGS="-C cpu-target=native" cargo +nightly test --features neon
```