### PR TITLE
updated the tremor script integer parse function documentation

### DIFF
--- a/tremor-script/lib/std/integer.tremor
+++ b/tremor-script/lib/std/integer.tremor
@@ -1,7 +1,7 @@
 ### The `integer` module contains functions to work with integers.
 
 ## Parses a string as an integer.
-## Returns an `float`.
+## Returns an `integer`.
 intrinsic fn parse(string) as integer::parse;
 
 mod signed with


### PR DESCRIPTION
The integer parse function has a typo. Updating the return type from `float` to `integer`.