### PR TITLE
Make release rpm compatible with centos7

### DIFF
--- a/.rpm/tremor.spec
+++ b/.rpm/tremor.spec
@@ -32,21 +32,12 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildRequires: systemd
 %endif
 
-# TODO make sure our package works on glibc 2.17 (for centos 7 support) for x86_64.
-# the binary is built on image tremorproject/tremor-builder:x86_64-unknown-linux-gnu,
-# (debian buster) which has glibc 2.28, so will probably need to try from older images
-# with older glibc (and still ensure that tremor compiles there).
-Requires: glibc >= 2.18
+# keep this in sync with the deb dependencies (in Cargo.toml)
+Requires: glibc >= 2.17
 # TODO link to these statically?
 # via snmalloc
 Requires: libstdc++
 Requires: libatomic
-# via surf
-Requires: libcurl
-# via surf and rdkafka. provides libz
-Requires: zlib
-# via xz2 (in tremor-script). provides liblzma
-Requires: xz
 
 # for user/group creation
 Requires(post): shadow-utils

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2846,6 +2846,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.10.2+1.1.1g"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a287fdb22e32b5b60624d4a5a7a02dbe82777f730ec0dbc42a0554326fef5a70"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2854,6 +2863,7 @@ dependencies = [
  "autocfg 1.0.0",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -4911,6 +4921,7 @@ dependencies = [
  "matches",
  "memmap",
  "mio 0.7.0",
+ "openssl",
  "postgres",
  "postgres-protocol",
  "pretty_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2846,15 +2846,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
-name = "openssl-src"
-version = "111.10.2+1.1.1g"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a287fdb22e32b5b60624d4a5a7a02dbe82777f730ec0dbc42a0554326fef5a70"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2863,7 +2854,6 @@ dependencies = [
  "autocfg 1.0.0",
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -4921,7 +4911,6 @@ dependencies = [
  "matches",
  "memmap",
  "mio 0.7.0",
- "openssl",
  "postgres",
  "postgres-protocol",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ grok = "1"
 
 # not used directly in tremor codebase, but present here so that we can turn
 # on features for these (see static-ssl feature here)
-openssl = { version = "0.10" }
+#openssl = { version = "0.10" }
 
 [dependencies.tungstenite]
 version = "0.11"
@@ -126,7 +126,7 @@ gcp = [ "google-storage1", "google-pubsub1", "hyper-rustls", "yup-oauth2", "hype
 # for compiling and statically linking to openssl. helps us create more
 # portable builds by side-stepping issues with openssl dynamic linking
 # (eg: latest version of openssl not available in old distros like centos 7)
-static-ssl = ["openssl/vendored"]
+#static-ssl = ["openssl/vendored"]
 
 [patch.crates-io]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,10 @@ hyper = { version = "0.13", optional = true }  # chan't update this because of g
 # logstash grok patterns
 grok = "1"
 
+# not used directly in tremor codebase, but present here so that we can turn
+# on features for these (see static-ssl feature here)
+openssl = { version = "0.10" }
+
 [dependencies.tungstenite]
 version = "0.11"
 default-features = false
@@ -119,15 +123,20 @@ neon = [ "simd-json/neon" ]
 # Experimental suport for google cloud APIs
 gcp = [ "google-storage1", "google-pubsub1", "hyper-rustls", "yup-oauth2", "hyper" ]
 
+# for compiling and statically linking to openssl. helps us create more
+# portable builds by side-stepping issues with openssl dynamic linking
+# (eg: latest version of openssl not available in old distros like centos 7)
+static-ssl = ["openssl/vendored"]
+
 [patch.crates-io]
-#  waiting for https://github.com/http-rs/tide/pull/408
 
 # for use during debian packaging, via cargo-deb
 # https://github.com/mmstick/cargo-deb#packagemetadatadeb-options
 [package.metadata.deb]
 name = "tremor"
 section = "net"
-depends = "$auto"
+# keep this in sync with the rpm dependencies (in rpm spec file)
+depends = "libc6 (>= 2.17), libstdc++6, libatomic1"
 maintainer-scripts = "packaging/distribution/debian/maintainer-scripts/"
 assets = [
   # target path will be automatically corrected when cross-compiling

--- a/Cross.toml
+++ b/Cross.toml
@@ -37,3 +37,6 @@ image = "tremorproject/tremor-builder:x86_64-alpine-linux-musl"
 
 [target.x86_64-unknown-linux-gnu]
 image = "tremorproject/tremor-builder:x86_64-unknown-linux-gnu"
+# useful if we want to support additional build on debian for debian packages
+# (above image is centos7 based).
+#image = "tremorproject/tremor-builder:x86_64-unknown-linux-gnu.debian"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,16 @@ RELEASE_TARGETS := \
 # fully static binaries (for easier distribution), but we are seeing up to
 # 25% slowdown for some of our benchmarks with musl builds. So we stick with
 # gnu builds for now.
-RELEASE_FORMATS_x86_64-unknown-linux-gnu := archive,deb,rpm
+#
+# The deb packaging is disabled here for now, since we currently make the binary
+# for x86_64-unknown-linux-gnu target in a centos7 docker container and binary
+# produced there does not easily port to debian (due to the dynamic ssl linking).
+# TODO resolve how we want to handle debian package building: either statically
+# link openssl from the centos7 image, or separate out binary building for debian
+# packaging using debian image itself (might also need to have separate build for
+# archive packaging too).
+#RELEASE_FORMATS_x86_64-unknown-linux-gnu := archive,deb,rpm
+RELEASE_FORMATS_x86_64-unknown-linux-gnu := archive,rpm
 RELEASE_FORMATS_x86_64-alpine-linux-musl := archive
 #RELEASE_FORMATS_x86_64-unknown-linux-musl := archive
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -62,7 +62,7 @@ For the list of formats used during project release (variable by target), please
 
 | Target | Format | Supported Platforms |
 | -------| -------| --------------------|
-| x86_64-unknown-linux-gnu | archive | Should work on all linux systems with glibc (>=2.17), libstdc++, libatomic |
-| x86_64-unknown-linux-gnu | deb | Debian jessie/stretch/buster as well as its derivatives like Ubuntu |
+| x86_64-unknown-linux-gnu | archive | Should work on linux systems with glibc (>=2.17), libstdc++, libatomic, libssl (==1.0.2) |
+| x86_64-unknown-linux-gnu | deb | ~Debian jessie/stretch/buster as well as its derivatives like Ubuntu~ TODO |
 | x86_64-unknown-linux-gnu | rpm | Centos7/8 |
 | x86_64-alpine-linux-musl | archive | Should work on all linux systems but not as [performant](https://github.com/wayfair-tremor/tremor-runtime/issues/377) as the gnu releases |

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -56,4 +56,13 @@ For the list of targets used during project release, please refer to the [projec
 * deb ([Debian package](https://www.debian.org/doc/debian-policy/ch-binary.html))
 * rpm ([RPM package](https://rpm.org/))
 
-For the list of formats used during project release (variable by target), please refer to the [project Makefile](../Makefile).
+For the list of formats used during project release (variable by target), please refer to the [project Makefile](../Makefile). A summary is given down below too.
+
+## Release Compatibility
+
+| Target | Format | Supported Platforms |
+| -------| -------| --------------------|
+| x86_64-unknown-linux-gnu | archive | Should work on all linux systems with glibc (>=2.17), libstdc++, libatomic |
+| x86_64-unknown-linux-gnu | deb | Debian jessie/stretch/buster as well as its derivatives like Ubuntu |
+| x86_64-unknown-linux-gnu | rpm | Centos7/8 |
+| x86_64-alpine-linux-musl | archive | Should work on all linux systems but not as [performant](https://github.com/wayfair-tremor/tremor-runtime/issues/377) as the gnu releases |

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -54,5 +54,6 @@ For the list of targets used during project release, please refer to the [projec
 
 * archive ([tar.gz](https://en.wikipedia.org/wiki/Tar_(computing)) for linux targets)
 * deb ([Debian package](https://www.debian.org/doc/debian-policy/ch-binary.html))
+* rpm ([RPM package](https://rpm.org/))
 
 For the list of formats used during project release (variable by target), please refer to the [project Makefile](../Makefile).

--- a/packaging/builder-images/Dockerfile.x86_64-alpine-linux-musl
+++ b/packaging/builder-images/Dockerfile.x86_64-alpine-linux-musl
@@ -37,3 +37,6 @@ RUN apk add --update-cache \
 #ENV PATH="/root/.cargo/bin:${PATH}"
 #
 #RUN rustup target add x86_64-unknown-linux-musl
+
+COPY shared/entrypoint.sh /
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/packaging/builder-images/Dockerfile.x86_64-unknown-linux-gnu
+++ b/packaging/builder-images/Dockerfile.x86_64-unknown-linux-gnu
@@ -1,9 +1,50 @@
-ARG RUST_VERSION
+# https://hub.docker.com/_/centos
+FROM centos:7.8.2003
 
-# update the version here as needed
-# may bring updates to things like glibc so proceed carefully.
-# via https://hub.docker.com/_/rust
-FROM rust:${RUST_VERSION}-buster
+# install extra software repos
+RUN yum install --assumeyes \
+    centos-release-scl `# provides devtoolset-9*` \
+    epel-release       `# provides deps like cmake3 and clang`
 
-COPY shared/install_dependencies_debian.sh /
-RUN /install_dependencies_debian.sh
+# get gcc9 via devtoolset-9, since gcc4 available from centos7 repos does not
+# work for compiling our dependencies like snmalloc
+# https://access.redhat.com/documentation/en-us/red_hat_developer_toolset/9/html/9.0_release_notes/dts9.0_release
+RUN yum install --assumeyes devtoolset-9-gcc devtoolset-9-gcc-c++ make
+
+# install cmake3 and link it as cmake (cmake >=3.8.2 needed for snmalloc)
+RUN yum install --assumeyes cmake3 \
+    && ln -s /usr/bin/cmake3 /usr/bin/cmake
+
+# install other system deps
+RUN yum install --assumeyes \
+    clang                        `# for onig_sys (via the regex crate)` \
+    devtoolset-9-libatomic-devel `# for snmalloc` \
+    openssl-devel                `# for dynamically linking against libssl1.0 (as part of openssl crate)` \
+    perl                         `# for compiling & statically linking openssl (as part of openssl crate's vendored feature)`
+
+# for dynamically linking against libssl1.1 (as part of openssl crate)
+# centos7 has libssl1.0 by default and 1.1 is only available from epel
+#RUN yum install --assumeyes openssl11-devel
+## set variables utilized by rust openssl crate so that it knows to link against
+## libssl1.1 (default in centos7 is libssl1.0)
+## https://docs.rs/openssl/*/openssl/#manual
+#ENV OPENSSL_INCLUDE_DIR=/usr/include/openssl11 \
+#    OPENSSL_LIB_DIR=/usr/lib64/openssl11
+
+# claim back some space
+RUN yum clean all
+
+# install rust
+# this is not needed right now since we are using this image from cross and
+# it already shares rust from the host to the image container. also saves us
+# from needing to update this image to keep up with rust version releases.
+#
+# TODO the cargo bin path is also not readable by cross docker user
+#ARG RUST_VERSION
+#RUN curl --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh \
+#    && sh rustup-init.sh -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION \
+#    && rm rustup-init.sh
+#ENV PATH="/root/.cargo/bin:${PATH}"
+
+COPY shared/entrypoint.sh /
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/packaging/builder-images/Dockerfile.x86_64-unknown-linux-gnu.debian
+++ b/packaging/builder-images/Dockerfile.x86_64-unknown-linux-gnu.debian
@@ -1,0 +1,12 @@
+ARG RUST_VERSION
+
+# update the version here as needed
+# may bring updates to things like glibc so proceed carefully.
+# via https://hub.docker.com/_/rust
+FROM rust:${RUST_VERSION}-buster
+
+COPY shared/install_dependencies_debian.sh /
+RUN /install_dependencies_debian.sh
+
+COPY shared/entrypoint.sh /
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/packaging/builder-images/Dockerfile.x86_64-unknown-linux-musl
+++ b/packaging/builder-images/Dockerfile.x86_64-unknown-linux-musl
@@ -31,3 +31,6 @@ RUN rustup target add x86_64-unknown-linux-musl
 
 COPY shared/install_dependencies_debian.sh /
 RUN /install_dependencies_debian.sh
+
+COPY shared/entrypoint.sh /
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/packaging/builder-images/shared/entrypoint.sh
+++ b/packaging/builder-images/shared/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Entrypoint script for our builder images
+
+# enable access to recent gcc version when running on centos images
+if [ -f /etc/centos-release ]; then
+  source scl_source enable devtoolset-9
+fi
+
+set -o xtrace
+
+# diagnostics usful for debugging
+id
+ldd --version
+gcc --version
+
+exec "$@"

--- a/packaging/cross_build.sh
+++ b/packaging/cross_build.sh
@@ -53,11 +53,18 @@ if ! command -v cross > /dev/null 2>&1; then
   cargo install --git https://github.com/rust-embedded/cross.git
 fi
 
-# locked flag is good for reproducible builds -- ensures that Cargo.lock is
-# always up-to-date (i.e. build will error out if it needs an update). This
-# also means it catches situations where we update versions in Cargo.toml
-# but forget to update Cargo.lock.
-BUILD_ARGS=("--target" "$TARGET" --locked)
+BUILD_ARGS=(
+  "--target" "$TARGET"
+
+  # useful features to turn on
+  "--features" "static-ssl"
+
+  # locked flag is good for reproducible builds -- ensures that Cargo.lock is
+  # always up-to-date (i.e. build will error out if it needs an update). This
+  # also means it catches situations where we update versions in Cargo.toml
+  # but forget to update Cargo.lock.
+  "--locked"
+)
 
 CUSTOM_RUSTFLAGS=()
 RUSTC_TARGET_FEATURES=()

--- a/packaging/cross_build.sh
+++ b/packaging/cross_build.sh
@@ -57,7 +57,7 @@ BUILD_ARGS=(
   "--target" "$TARGET"
 
   # useful features to turn on
-  "--features" "static-ssl"
+  #"--features" "static-ssl"
 
   # locked flag is good for reproducible builds -- ensures that Cargo.lock is
   # always up-to-date (i.e. build will error out if it needs an update). This


### PR DESCRIPTION
Resolves https://github.com/wayfair-tremor/tremor-runtime/issues/279#issuecomment-646644975.

Successfully tested the installation of the resulting rpm (produced via `make package-x86_64-unknown-linux-gnu`) on a centos7 system.

On centos8, the rpm continues to work. Centos8 comes with `libssl1.1` by default but the dynamic linking requirement to `libssl1.0.2` is provided via `compat-openssl10` package.

We choose not to support centos6 since that's [nearing end-of-life](https://wiki.centos.org/About/Product) and also because tremor compilation there is [trickier](https://gist.github.com/anupdhml/fff25acf3e4eb86599ccfe982de86c4f) and more prone to breakage. 

---

Will publish the new tremor-builder images here once the PR is approved.